### PR TITLE
[FEAT] 여행 기록 API 구현

### DIFF
--- a/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
@@ -1,0 +1,18 @@
+package com.ssafy.tlog.config.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**") // 또는 모든 요청이라면 "/**"
+                .allowedOrigins("http://localhost:5173") // 개발 서버 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true); // 쿠키를 주고받을 경우
+    }
+}

--- a/src/main/java/com/ssafy/tlog/entity/TripRecord.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripRecord.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,5 +19,6 @@ public class TripRecord {
     private int tripId;
     private int userId;
     private int day;
+    private LocalDateTime date;
     private String memo;
 }

--- a/src/main/java/com/ssafy/tlog/entity/TripRecord.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripRecord.java
@@ -19,6 +19,5 @@ public class TripRecord {
     private int tripId;
     private int userId;
     private int day;
-    private LocalDateTime date;
     private String memo;
 }

--- a/src/main/java/com/ssafy/tlog/entity/TripRecord.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripRecord.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/ssafy/tlog/exception/custom/ResourceNotFoundException.java
+++ b/src/main/java/com/ssafy/tlog/exception/custom/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ssafy.tlog.exception.custom;
+
+public class ResourceNotFoundException extends RuntimeException{
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ssafy/tlog/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/ssafy/tlog/exception/global/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ssafy.tlog.exception.global;
 import com.ssafy.tlog.exception.custom.InvalidTokenException;
 import com.ssafy.tlog.exception.custom.InvalidUserException;
 import com.ssafy.tlog.exception.custom.NicknameConflictException;
+import com.ssafy.tlog.exception.custom.ResourceNotFoundException;
 import com.ssafy.tlog.exception.custom.SocialIdConflictException;
 import com.ssafy.tlog.exception.custom.TokenExpiredException;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +57,7 @@ public class GlobalExceptionHandler {
     // 401 UNAUTHORIZED
     @ExceptionHandler({UsernameNotFoundException.class, InvalidUserException.class, TokenExpiredException.class,
             InvalidTokenException.class})
-    public ResponseEntity<ErrorResponse> handleUNAUTHORIZED(Exception e) {
+    public ResponseEntity<ErrorResponse> handleUnauthorized(Exception e) {
         ErrorResponse error = new ErrorResponse(
                 401,
                 "UNAUTHORIZED",
@@ -65,12 +66,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(401).body(error);
     }
 
-    // 409 Conflict
+    // 404 NOT_FOUND
+    @ExceptionHandler({ResourceNotFoundException.class})
+    public ResponseEntity<ErrorResponse> handleNotFound(Exception e) {
+        ErrorResponse error = new ErrorResponse(
+                404,
+                "NOT_FOUND",
+                e.getMessage()
+        );
+        return ResponseEntity.status(404).body(error);
+    }
+
+    // 409 CONFLICT
     @ExceptionHandler({NicknameConflictException.class, SocialIdConflictException.class})
     public ResponseEntity<ErrorResponse> handleConflict(Exception e) {
         ErrorResponse error = new ErrorResponse(
                 409,
-                "Conflict",
+                "CONFLICT",
                 e.getMessage()
         );
         return ResponseEntity.status(409).body(error);

--- a/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
@@ -1,8 +1,10 @@
 package com.ssafy.tlog.repository;
 
 import com.ssafy.tlog.entity.AiStory;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AiStoryRepository extends JpaRepository<AiStory, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
+    Optional<AiStory> findByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
@@ -10,4 +10,5 @@ public interface TripParticipantRepository extends JpaRepository<TripParticipant
 
     List<TripParticipant> findAllByUserId(int userId);
     List<TripParticipant> findAllByTripIdIn(List<Integer> tripIds);
+    boolean existsByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
@@ -1,8 +1,10 @@
 package com.ssafy.tlog.repository;
 
 import com.ssafy.tlog.entity.TripPlan;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripPlanRepository extends JpaRepository<TripPlan, Integer> {
-
+    List<TripPlan> findAllByTripIdOrderByDayAscPlanOrderAsc(int tripId);
+    boolean existsByTripId(int tripId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
@@ -1,8 +1,10 @@
 package com.ssafy.tlog.repository;
 
 import com.ssafy.tlog.entity.TripRecord;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordRepository extends JpaRepository<TripRecord, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
+    List<TripRecord> findAllByTripIdOrderByDay(int tripId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordRepository extends JpaRepository<TripRecord, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
-    List<TripRecord> findAllByTripIdOrderByDay(int tripId);
+    List<TripRecord> findAllByTripIdAndUserIdOrderByDay(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/trip/record/controller/TripRecordController.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/controller/TripRecordController.java
@@ -3,13 +3,16 @@ package com.ssafy.tlog.trip.record.controller;
 import com.ssafy.tlog.common.response.ApiResponse;
 import com.ssafy.tlog.common.response.ResponseWrapper;
 import com.ssafy.tlog.config.security.CustomUserDetails;
+import com.ssafy.tlog.trip.record.dto.TripRecordDetailResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto;
 import com.ssafy.tlog.trip.record.service.RecordService;
+import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +26,11 @@ public class TripRecordController {
     public ResponseEntity<ResponseWrapper<TripRecordListResponseDto>> getTripRecordList(@AuthenticationPrincipal CustomUserDetails userDetails) {
         TripRecordListResponseDto tripRecordListResponseDto = recordService.getTripRecordListByUser(userDetails.getUserId());
         return ApiResponse.success(HttpStatus.OK, "여행 기록 리스트 조회에 성공했습니다.", tripRecordListResponseDto);
+    }
+
+    @GetMapping("/{tripId}/record")
+    public ResponseEntity<ResponseWrapper<TripRecordDetailResponseDto>> getTripRecordDetail(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable int tripId) {
+        TripRecordDetailResponseDto tripRecordDetailResponseDto = recordService.getTripRecordDetailByTripId(userDetails.getUserId(), tripId);
+        return ApiResponse.success(HttpStatus.OK, "여행 기록 상세 조회에 성공했습니다.",tripRecordDetailResponseDto);
     }
 }

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripPlanResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripPlanResponseDto.java
@@ -1,0 +1,33 @@
+package com.ssafy.tlog.trip.record.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripPlanResponseDto {
+    private int day;
+    private List<PlanDetailDto> plans;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlanDetailDto {
+        private int planId;
+        private int cityId;
+        private int placeId;
+        private int planOrder;
+        private double latitude;
+        private double longitude;
+        private String memo;
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
@@ -18,6 +18,7 @@ public class TripRecordDetailResponseDto {
     private List<Integer> tripParticipant;
     private boolean hasStep1;
     private boolean hasStep2;
+    private List<TripPlanResponseDto> tripPlans;
     private List<TripRecordDto> tripRecords;
     private String aiStoryContent;
 
@@ -27,6 +28,7 @@ public class TripRecordDetailResponseDto {
     @AllArgsConstructor
     @Builder
     public static class TripDto {
+        private int tripId;
         private String title;
         private LocalDateTime createdAt;
         private LocalDateTime startDate;
@@ -39,6 +41,7 @@ public class TripRecordDetailResponseDto {
     @AllArgsConstructor
     @Builder
     public static class TripRecordDto {
+        private int recordId;
         private int day;
         private LocalDateTime date;
         private String memo;

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
@@ -1,0 +1,46 @@
+package com.ssafy.tlog.trip.record.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripRecordDetailResponseDto {
+    private TripDto trip;
+    private List<Integer> tripParticipant;
+    private boolean hasStep1;
+    private boolean hasStep2;
+    private List<TripRecordDto> tripRecords;
+    private String aiStoryContent;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TripDto {
+        private String title;
+        private LocalDateTime createdAt;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TripRecordDto {
+        private int day;
+        private LocalDateTime date;
+        private String memo;
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordListResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordListResponseDto.java
@@ -34,7 +34,6 @@ public class TripRecordListResponseDto {
     @AllArgsConstructor
     @Builder
     public static class TripDto {
-        private int tripId;
         private String title;
         private LocalDateTime createdAt;
         private LocalDateTime startDate;

--- a/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
@@ -67,8 +67,8 @@ public class RecordService {
         // 3. 여행 관련 정보 조회
         List<Integer> tripIds = List.of(tripId);
         Map<Integer, List<Integer>> participantsMap = getTripParticipantsMap(tripIds, userId);
-        boolean hasStep1 = getHasStep1Map(tripIds, userId).getOrDefault(tripId, false);
-        boolean hasStep2 = getHasStep2Map(tripIds, userId).getOrDefault(tripId, false);
+        boolean hasStep1 = tripRecordRepository.existsByTripIdAndUserId(tripId, userId);
+        boolean hasStep2 = aiStoryRepository.existsByTripIdAndUserId(tripId, userId);
 
         // 4. 여행 기록 조회 - 없으면 빈 리스트 반환
         List<TripRecord> tripRecords = tripRecordRepository.findAllByTripIdOrderByDay(tripId);

--- a/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
@@ -1,21 +1,29 @@
 package com.ssafy.tlog.trip.record.service;
 
+import com.ssafy.tlog.entity.AiStory;
 import com.ssafy.tlog.entity.Trip;
 import com.ssafy.tlog.entity.TripParticipant;
+import com.ssafy.tlog.entity.TripRecord;
+import com.ssafy.tlog.exception.custom.InvalidUserException;
+import com.ssafy.tlog.exception.custom.ResourceNotFoundException;
 import com.ssafy.tlog.repository.AiStoryRepository;
 import com.ssafy.tlog.repository.TripParticipantRepository;
 import com.ssafy.tlog.repository.TripRecordRepository;
 import com.ssafy.tlog.repository.TripRepository;
+import com.ssafy.tlog.trip.record.dto.TripRecordDetailResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto.TripDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto.TripInfoDto;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,30 +34,76 @@ public class RecordService {
     private final TripRecordRepository tripRecordRepository;
     private final AiStoryRepository aiStoryRepository;
 
+    @Transactional(readOnly = true)
     public TripRecordListResponseDto getTripRecordListByUser(int userId) {
-        // 사용자가 참여한 여행 ID 목록 조회
-        List<TripParticipant> participants = tripParticipantRepository.findAllByUserId(userId);
-        List<Integer> tripIds = participants.stream().map(TripParticipant::getTripId).collect(Collectors.toList());
+        // 1. 사용자가 참여한 여행 ID 목록 조회
+        List<Integer> tripIds = getUserTripIds(userId);
+        if (tripIds.isEmpty()) {
+            return TripRecordListResponseDto.builder().trips(Collections.emptyList()).build();
+        }
 
-        // 여행 기본 정보 조회
+        // 2. 여행 기본 정보 조회
         List<Trip> trips = tripRepository.findAllByTripIdIn(tripIds);
 
-        // 각 여행별 참여자 목록 조회(현재 사용자 제외)
+        // 3. 여행 관련 정보 맵 조회 (참여자, 단계별 상태)
         Map<Integer, List<Integer>> tripParticipantsMap = getTripParticipantsMap(tripIds, userId);
-
-        // 각 여행 별 기록 저장 여부 확인
         Map<Integer, Boolean> hasStep1Map = getHasStep1Map(tripIds, userId);
-
-        // 각 여행별 AI 생성 저장 여부 확인
         Map<Integer, Boolean> hasStep2Map = getHasStep2Map(tripIds, userId);
 
-        // 응답 생성
+        // 4. 응답 DTO 생성
         List<TripInfoDto> tripInfoDtos = createTripInfoDtos(trips, tripParticipantsMap, hasStep1Map, hasStep2Map);
 
         return TripRecordListResponseDto.builder().trips(tripInfoDtos).build();
     }
 
-    // 각 여행별 참여자 목록 조회(현재 사용자 제외)
+    @Transactional(readOnly = true)
+    public TripRecordDetailResponseDto getTripRecordDetailByTripId(int userId, int tripId) {
+        // 1. 여행 존재 여부 확인
+        Trip trip = validateAndGetTrip(tripId);
+
+        // 2. 사용자 접근 권한 확인
+        validateUserAccess(tripId, userId);
+
+        // 3. 여행 관련 정보 조회
+        List<Integer> tripIds = List.of(tripId);
+        Map<Integer, List<Integer>> participantsMap = getTripParticipantsMap(tripIds, userId);
+        boolean hasStep1 = getHasStep1Map(tripIds, userId).getOrDefault(tripId, false);
+        boolean hasStep2 = getHasStep2Map(tripIds, userId).getOrDefault(tripId, false);
+
+        // 4. 여행 기록 조회 - 없으면 빈 리스트 반환
+        List<TripRecord> tripRecords = tripRecordRepository.findAllByTripIdOrderByDay(tripId);
+
+        // 5. AI 스토리 조회 - 없으면 null 반환
+        String aiStoryContent = getAiStoryContent(tripId, userId, hasStep2);
+
+        // 6. 응답 DTO 생성
+        return buildDetailResponseDto(trip, participantsMap.get(tripId), hasStep1, hasStep2,
+                tripRecords, aiStoryContent);
+    }
+
+    // 여행 기본 검증
+    private Trip validateAndGetTrip(int tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResourceNotFoundException("요청한 여행을 찾을 수 없습니다."));
+    }
+
+    // 사용자 접근 권한 검증
+    private void validateUserAccess(int tripId, int userId) {
+        boolean isParticipant = tripParticipantRepository.existsByTripIdAndUserId(tripId, userId);
+        if (!isParticipant) {
+            throw new InvalidUserException("해당 여행 기록에 접근 권한이 없습니다.");
+        }
+    }
+
+    // 사용자의 여행 ID 목록 조회
+    private List<Integer> getUserTripIds(int userId) {
+        List<TripParticipant> participants = tripParticipantRepository.findAllByUserId(userId);
+        return participants.stream()
+                .map(TripParticipant::getTripId)
+                .collect(Collectors.toList());
+    }
+
+    // 여행 참여자 맵 조회
     private Map<Integer, List<Integer>> getTripParticipantsMap(List<Integer> tripIds, int userId) {
         // 모든 여행의 참여자 정보 조회
         List<TripParticipant> allParticipants = tripParticipantRepository.findAllByTripIdIn(tripIds);
@@ -74,6 +128,7 @@ public class RecordService {
         return participantsMap;
     }
 
+    // Step1 상태 맵 조회
     private Map<Integer, Boolean> getHasStep1Map(List<Integer> tripIds, int userId) {
         Map<Integer, Boolean> hasStep1Map = new HashMap<>();
 
@@ -86,20 +141,35 @@ public class RecordService {
         return hasStep1Map;
     }
 
+    // Step2 상태 맵 조회
     private Map<Integer, Boolean> getHasStep2Map(List<Integer> tripIds, int userId) {
         Map<Integer, Boolean> hasStep2Map = new HashMap<>();
 
         // 각 여행 ID에 대해 AI 기록(Step2) 존재 여부 확인
         for (Integer tripId : tripIds) {
-            boolean hasStep1 = aiStoryRepository.existsByTripIdAndUserId(tripId, userId);
-            hasStep2Map.put(tripId, hasStep1);
+            boolean hasStep2 = aiStoryRepository.existsByTripIdAndUserId(tripId, userId);
+            hasStep2Map.put(tripId, hasStep2);
         }
 
         return hasStep2Map;
     }
 
-    private List<TripInfoDto> createTripInfoDtos(List<Trip> trips, Map<Integer, List<Integer>> tripParticipantsMap,
-                                                 Map<Integer, Boolean> hasStep1Map, Map<Integer, Boolean> hasStep2Map) {
+    // AI 스토리 내용 조회
+    private String getAiStoryContent(int tripId, int userId, boolean hasStep2) {
+        if (!hasStep2) {
+            return null;
+        }
+
+        return aiStoryRepository.findByTripIdAndUserId(tripId, userId)
+                .map(AiStory::getContent)
+                .orElse(null);
+    }
+
+    // 목록 응답 DTO 생성
+    private List<TripInfoDto> createTripInfoDtos(List<Trip> trips,
+                                                 Map<Integer, List<Integer>> tripParticipantsMap,
+                                                 Map<Integer, Boolean> hasStep1Map,
+                                                 Map<Integer, Boolean> hasStep2Map) {
         return trips.stream()
                 .map(trip -> {
                     // Trip 엔티티를 TripDto로 변환
@@ -120,4 +190,43 @@ public class RecordService {
                 })
                 .collect(Collectors.toList());
     }
+
+    // 상세 응답 DTO 생성
+    private TripRecordDetailResponseDto buildDetailResponseDto(Trip trip, List<Integer> participants,
+                                                               boolean hasStep1, boolean hasStep2,
+                                                               List<TripRecord> tripRecords,
+                                                               String aiStoryContent) {
+        // TripDto 생성
+        TripRecordDetailResponseDto.TripDto tripDto = TripRecordDetailResponseDto.TripDto.builder()
+                .title(trip.getTitle())
+                .createdAt(trip.getCreateAt())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .build();
+
+        // 날짜별 기록 DTO 생성
+        List<TripRecordDetailResponseDto.TripRecordDto> recordDtos = tripRecords.stream()
+                .map(record -> {
+                    // 여행 시작일로부터 day만큼 더하여 날짜 계산
+                    LocalDateTime date = trip.getStartDate().plusDays(record.getDay() - 1);
+
+                    return TripRecordDetailResponseDto.TripRecordDto.builder()
+                            .day(record.getDay())
+                            .date(date)
+                            .memo(record.getMemo())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // 최종 응답 DTO 조합
+        return TripRecordDetailResponseDto.builder()
+                .trip(tripDto)
+                .tripParticipant(participants)
+                .hasStep1(hasStep1)
+                .hasStep2(hasStep2)
+                .tripRecords(recordDtos)
+                .aiStoryContent(aiStoryContent)
+                .build();
+    }
+
 }

--- a/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
@@ -104,7 +104,6 @@ public class RecordService {
                 .map(trip -> {
                     // Trip 엔티티를 TripDto로 변환
                     TripDto tripDto = TripDto.builder()
-                            .tripId(trip.getTripId())
                             .title(trip.getTitle())
                             .createdAt(trip.getCreateAt())
                             .startDate(trip.getStartDate())


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 여행 기록 API 엔드포인트 설계 및 구현

## 📌 이슈 넘버
- #9 

## 📝 작업 내용
- 여행 기록 리스트 조회 API 구현 (GET /api/trips/record)
- 기록 디테일 조회 API 구현 (GET /api/trips/{tripId}/record)
- Day 전체 메모 저장 API 구현 (POST /api/trips/{tripId}/record/save)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 특정 여행의 상세 기록 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
    - 여행 계획, 여행 기록, AI가 생성한 스토리, 참가자 목록 등 상세 정보를 포함하는 응답이 제공됩니다.

- **버그 수정**
    - 일부 불일치했던 필드명 및 상태 문자열이 일관되게 수정되었습니다.

- **개선 사항**
    - 예외 처리 및 접근 권한 검증이 강화되어, 잘못된 접근 시 명확한 오류 메시지가 반환됩니다.
    - 여행 기록 리스트 및 상세 정보 응답 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->