### PR TITLE
[FEAT] 여행 계획 생성 API 구현

### DIFF
--- a/src/main/java/com/ssafy/tlog/common/response/ApiResponse.java
+++ b/src/main/java/com/ssafy/tlog/common/response/ApiResponse.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class ApiResponse {
+public class ApiResponse<T> {
 
     // 상태코드 + 메시지
     public static <T> ResponseEntity<ResponseWrapper<Void>> success(HttpStatus status, String message) {

--- a/src/main/java/com/ssafy/tlog/entity/City.java
+++ b/src/main/java/com/ssafy/tlog/entity/City.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 @Entity
 public class City {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int cityId;
     private String cityEn;
     private String cityKo;

--- a/src/main/java/com/ssafy/tlog/entity/PlaceType.java
+++ b/src/main/java/com/ssafy/tlog/entity/PlaceType.java
@@ -1,0 +1,15 @@
+package com.ssafy.tlog.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class PlaceType {
+    @Id
+    private int placeTypeId;
+    private String placeTypeName;
+}

--- a/src/main/java/com/ssafy/tlog/entity/Trip.java
+++ b/src/main/java/com/ssafy/tlog/entity/Trip.java
@@ -5,10 +5,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
-import lombok.Getter;
-import lombok.Setter;
+
+import lombok.*;
 import org.springframework.cglib.core.Local;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 @Entity
@@ -16,8 +19,7 @@ public class Trip {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int tripId;
-
-    private int userId;
+    private int cityId;
     private String title;
     private LocalDateTime createAt;
     private LocalDateTime startDate;

--- a/src/main/java/com/ssafy/tlog/entity/TripParticipant.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripParticipant.java
@@ -3,9 +3,11 @@ package com.ssafy.tlog.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 @Entity

--- a/src/main/java/com/ssafy/tlog/entity/TripPlan.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripPlan.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 @Entity
@@ -14,10 +16,10 @@ public class TripPlan {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int planId;
-
-    private int cityId;
+    private String placeName;
     private int tripId;
-    private int placeId;
+    private int placeTypeId;
+    private String placeId;
     private int day;
     private int planOrder ;
     private double latitude;

--- a/src/main/java/com/ssafy/tlog/repository/PlaceTypeRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/PlaceTypeRepository.java
@@ -1,0 +1,8 @@
+package com.ssafy.tlog.repository;
+
+import com.ssafy.tlog.entity.PlaceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceTypeRepository extends JpaRepository<PlaceType, Integer> {
+
+}

--- a/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
@@ -1,0 +1,34 @@
+package com.ssafy.tlog.trip.plan.controller;
+
+import com.ssafy.tlog.common.response.ApiResponse;
+import com.ssafy.tlog.common.response.ResponseWrapper;
+import com.ssafy.tlog.config.security.CustomUserDetails;
+import com.ssafy.tlog.trip.plan.dto.TripPlanRequestDto;
+import com.ssafy.tlog.trip.plan.dto.TripPlanResponseDto;
+import com.ssafy.tlog.trip.plan.service.TripPlanService;
+import com.ssafy.tlog.trip.record.dto.TripRecordResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trips")
+public class TripPlanController {
+
+    private final TripPlanService tripPlanService;
+
+    @PostMapping("/plan")
+    public ResponseEntity<ResponseWrapper<TripPlanResponseDto>> createTripPlan(
+            @RequestBody TripPlanRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripPlanResponseDto responseDto = tripPlanService.createTripPlan(requestDto, userDetails.getUser());
+        return ApiResponse.success(HttpStatus.OK, "여행 계획이 성공적으로 저장되었습니다.",responseDto);
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanRequestDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanRequestDto.java
@@ -1,0 +1,32 @@
+package com.ssafy.tlog.trip.plan.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class TripPlanRequestDto {
+
+    private List<Integer> friendUserIds;
+    private int cityId;
+    private String title;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private List<PlaceDto> places;
+
+    @Getter
+    @NoArgsConstructor
+    public static class PlaceDto {
+        private String placeId;
+        private String name;
+        private Double latitude;
+        private Double longitude;
+        private int day;
+        private int order;
+        private int placeType; // "숙소" 또는 "명소"
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanResponseDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.tlog.trip.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TripPlanResponseDto {
+    private int tripId;
+}

--- a/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
@@ -1,0 +1,67 @@
+package com.ssafy.tlog.trip.plan.service;
+
+import com.ssafy.tlog.entity.*;
+import com.ssafy.tlog.repository.TripParticipantRepository;
+import com.ssafy.tlog.repository.TripPlanRepository;
+import com.ssafy.tlog.repository.TripRepository;
+import com.ssafy.tlog.trip.plan.dto.TripPlanRequestDto;
+import com.ssafy.tlog.trip.plan.dto.TripPlanResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlanService {
+
+    private final TripRepository tripRepository;
+    private final TripPlanRepository tripPlanRepository;
+    private final TripParticipantRepository tripParticipantRepository;
+
+    public TripPlanResponseDto createTripPlan(TripPlanRequestDto requestDto, User creator) {
+        Trip trip = Trip.builder()
+                .cityId(requestDto.getCityId())
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .createAt(LocalDateTime.now())
+                .title(requestDto.getTitle())
+                .build();
+        tripRepository.save(trip);
+
+        // 1. 사용자 본인 추가
+        TripParticipant creatorParticipant = TripParticipant.builder()
+                .tripId(trip.getTripId())
+                .userId(creator.getUserId())
+                .build();
+        tripParticipantRepository.save(creatorParticipant);
+
+// 2. 친구 추가
+        requestDto.getFriendUserIds().forEach(friendId -> {
+            TripParticipant friendParticipant = TripParticipant.builder()
+                    .tripId(trip.getTripId())
+                    .userId(friendId)
+                    .build();
+            tripParticipantRepository.save(friendParticipant);
+        });
+
+
+        for (TripPlanRequestDto.PlaceDto placeDto : requestDto.getPlaces()) {
+            TripPlan plan = TripPlan.builder()
+                    .tripId(trip.getTripId())
+                    .placeName(placeDto.getName())
+                    .placeId(placeDto.getPlaceId())
+                    .latitude(placeDto.getLatitude())
+                    .longitude(placeDto.getLongitude())
+                    .day(placeDto.getDay())
+                    .planOrder(placeDto.getOrder())
+                    .placeTypeId(placeDto.getPlaceType())
+                    .build();
+            tripPlanRepository.save(plan);
+        }
+
+        return TripPlanResponseDto.builder()
+                .tripId(trip.getTripId())
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
@@ -18,7 +18,7 @@ public class TripRecordDetailResponseDto {
     private List<Integer> tripParticipant;
     private boolean hasStep1;
     private boolean hasStep2;
-    private List<TripPlanResponseDto> tripPlans;
+    private List<TripRecordResponseDto> tripPlans;
     private List<TripRecordDto> tripRecords;
     private String aiStoryContent;
 

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordListResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordListResponseDto.java
@@ -35,6 +35,7 @@ public class TripRecordListResponseDto {
     @Builder
     public static class TripDto {
         private String title;
+        private int cityId;
         private LocalDateTime createdAt;
         private LocalDateTime startDate;
         private LocalDateTime endDate;

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordResponseDto.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TripPlanResponseDto {
+public class TripRecordResponseDto {
     private int day;
     private List<PlanDetailDto> plans;
 
@@ -23,8 +23,8 @@ public class TripPlanResponseDto {
     @AllArgsConstructor
     public static class PlanDetailDto {
         private int planId;
-        private int cityId;
-        private int placeId;
+//        private int cityId;
+        private String placeId;
         private int planOrder;
         private double latitude;
         private double longitude;

--- a/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/service/RecordService.java
@@ -12,7 +12,7 @@ import com.ssafy.tlog.repository.TripParticipantRepository;
 import com.ssafy.tlog.repository.TripPlanRepository;
 import com.ssafy.tlog.repository.TripRecordRepository;
 import com.ssafy.tlog.repository.TripRepository;
-import com.ssafy.tlog.trip.record.dto.TripPlanResponseDto;
+import com.ssafy.tlog.trip.record.dto.TripRecordResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordDetailResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto;
 import com.ssafy.tlog.trip.record.dto.TripRecordListResponseDto.TripDto;
@@ -76,7 +76,7 @@ public class RecordService {
         boolean hasStep2 = aiStoryRepository.existsByTripIdAndUserId(tripId, userId);
 
         // 4. 여행 계획 조회
-        List<TripPlanResponseDto> tripPlans = getTripPlans(tripId);
+        List<TripRecordResponseDto> tripPlans = getTripPlans(tripId);
 
         // 5. 여행 기록 조회
         List<TripRecord> tripRecords = tripRecordRepository.findAllByTripIdAndUserIdOrderByDay(tripId, userId);
@@ -89,7 +89,7 @@ public class RecordService {
                 aiStoryContent);
     }
 
-    private List<TripPlanResponseDto> getTripPlans(int tripId) {
+    private List<TripRecordResponseDto> getTripPlans(int tripId) {
         List<TripPlan> allPlans = tripPlanRepository.findAllByTripIdOrderByDayAscPlanOrderAsc(tripId);
 
         // 날짜별로 계획 그룹화
@@ -102,10 +102,10 @@ public class RecordService {
                     int day = entry.getKey();
                     List<TripPlan> plansForDay = entry.getValue();
 
-                    List<TripPlanResponseDto.PlanDetailDto> planDetails = plansForDay.stream()
-                            .map(plan -> TripPlanResponseDto.PlanDetailDto.builder()
+                    List<TripRecordResponseDto.PlanDetailDto> planDetails = plansForDay.stream()
+                            .map(plan -> TripRecordResponseDto.PlanDetailDto.builder()
                                     .planId(plan.getPlanId())
-                                    .cityId(plan.getCityId())
+//                                    .cityId(plan.getCityId())
                                     .placeId(plan.getPlaceId())
                                     .planOrder(plan.getPlanOrder())
                                     .latitude(plan.getLatitude())
@@ -114,7 +114,7 @@ public class RecordService {
                                     .build())
                             .collect(Collectors.toList());
 
-                    return TripPlanResponseDto.builder()
+                    return TripRecordResponseDto.builder()
                             .day(day)
                             .plans(planDetails)
                             .build();
@@ -217,6 +217,7 @@ public class RecordService {
                     // Trip 엔티티를 TripDto로 변환
                     TripDto tripDto = TripDto.builder()
                             .title(trip.getTitle())
+                            .cityId(trip.getCityId())
                             .createdAt(trip.getCreateAt())
                             .startDate(trip.getStartDate())
                             .endDate(trip.getEndDate())
@@ -236,7 +237,7 @@ public class RecordService {
     // 상세 응답 DTO 생성
     private TripRecordDetailResponseDto buildDetailResponseDto(Trip trip, List<Integer> participants,
                                                                boolean hasStep1, boolean hasStep2,
-                                                               List<TripPlanResponseDto> tripPlans, // 추가된 매개변수
+                                                               List<TripRecordResponseDto> tripPlans, // 추가된 매개변수
                                                                List<TripRecord> tripRecords,
                                                                String aiStoryContent) {
         // TripDto 생성


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
여행 계획 생성 API 구현

## 📌 이슈 넘버
- #14 

## 📝 작업 내용
- 여행 계획 생성 API 구현
- 일부 entity 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 여행 플랜 생성을 위한 REST API 엔드포인트가 추가되었습니다.
  - 여행 플랜 생성 및 관리를 위한 DTO, 서비스, 컨트롤러가 도입되었습니다.
  - 장소 유형(PlaceType) 관리 기능이 추가되었습니다.

- **기능 개선**
  - 여행 플랜 및 기록 관련 데이터 모델이 확장 및 개선되었습니다(필드 추가, 타입 변경 등).
  - 여행 참가자 및 플랜 엔터티에 빌더 패턴과 생성자 자동 생성 기능이 추가되었습니다.

- **버그 수정**
  - 일부 DTO 및 서비스에서 잘못된 필드 타입 및 명칭이 수정되었습니다.

- **기타**
  - 자동 생성되는 도시 ID 설정 방식이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->