### PR TITLE
[Feat] 홈페이지 도시 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/tlog/config/security/SecurityConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
             .formLogin(form -> form.disable())
             .httpBasic(basic -> basic.disable())
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-name","/api/auth/refresh").permitAll()  // 로그인, 회원가입, 닉네임 확인은 인증 없이 접근 가능
+                    .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-name","/api/auth/refresh","/api/home/*").permitAll()  // 로그인, 회원가입, 닉네임 확인은 인증 없이 접근 가능
                     .anyRequest().authenticated()
             )
             .addFilterBefore(new JWTFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ssafy/tlog/entity/City.java
+++ b/src/main/java/com/ssafy/tlog/entity/City.java
@@ -1,14 +1,18 @@
 package com.ssafy.tlog.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class City {
     @Id

--- a/src/main/java/com/ssafy/tlog/home/controller/CityController.java
+++ b/src/main/java/com/ssafy/tlog/home/controller/CityController.java
@@ -1,0 +1,28 @@
+package com.ssafy.tlog.home.controller;
+
+import com.ssafy.tlog.common.response.ApiResponse;
+import com.ssafy.tlog.common.response.ResponseWrapper;
+import com.ssafy.tlog.home.dto.CityResponseDto;
+import com.ssafy.tlog.home.service.CityService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/home")
+@RequiredArgsConstructor
+public class CityController {
+    private final CityService cityService;
+
+    @GetMapping("/cities")
+    public ResponseEntity<ResponseWrapper<CityResponseDto>> getCities(@RequestParam(required = false) String name) {
+        CityResponseDto cityResponseDto = cityService.getCities(name);
+        return ApiResponse.success(HttpStatus.OK, "도시 목록 조회에 성공했습니다.", cityResponseDto);
+    }
+}

--- a/src/main/java/com/ssafy/tlog/home/dto/CityResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/home/dto/CityResponseDto.java
@@ -1,0 +1,30 @@
+package com.ssafy.tlog.home.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CityResponseDto {
+    private List<CityDto> cities;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CityDto {
+        private int cityId;
+        private String cityEn;
+        private String cityKo;
+
+    }
+
+}

--- a/src/main/java/com/ssafy/tlog/home/service/CityService.java
+++ b/src/main/java/com/ssafy/tlog/home/service/CityService.java
@@ -1,0 +1,46 @@
+package com.ssafy.tlog.home.service;
+
+import com.ssafy.tlog.entity.City;
+import com.ssafy.tlog.home.dto.CityResponseDto;
+import com.ssafy.tlog.home.dto.CityResponseDto.CityDto;
+import com.ssafy.tlog.repository.CityRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CityService {
+    private final CityRepository cityRepository;
+
+    @Transactional(readOnly = true)
+    public CityResponseDto getCities(String name) {
+        // cities 변수 초기화
+        List<City> cities;
+
+        if (name != null && !name.trim().isEmpty()) {
+            cities = cityRepository.findByCityKoContainingOrCityEnContainingIgnoreCase(name, name);
+        } else {
+            cities = cityRepository.findAll();
+            log.warn(cities.toString());
+        }
+
+        // 변환 작업
+        List<CityDto> cityDtos = cities.stream()
+                .map(city -> CityDto.builder()
+                        .cityId(city.getCityId())
+                        .cityEn(city.getCityEn())
+                        .cityKo(city.getCityKo())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 결과 반환
+        return CityResponseDto.builder()
+                .cities(cityDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/tlog/repository/CityRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/CityRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.tlog.repository;
+
+import com.ssafy.tlog.entity.City;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CityRepository extends JpaRepository<City, Integer> {
+    List<City> findByCityKoContainingOrCityEnContainingIgnoreCase(String cityKo, String cityEn);
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -6,6 +6,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jwt.secret=${SPRING_JWT_SECRET}
 
 spring.ai.openai.api-key=${OPENAI_API_KEY}
-spring.ai.openai.model=gpt-4o
+spring.ai.openai.model=gpt-4o-mini
 spring.ai.openai.base-url=https://api.openai.com
 spring.ai.openai.base-path=/v1


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 홈페이지 - 도시 검색 및 조회 기능 구현

## 📌 이슈 넘버
- #20 

## 📝 작업 내용
- 도시 조회 API 엔드포인트 구현: /api/home/cities
- 도시 검색 기능: 한글/영문 도시명으로 검색 가능
- 전체 도시 목록 조회: 검색어 없이 전체 도시 목록 반환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 도시 목록을 조회할 수 있는 공개 API 엔드포인트(/api/home/cities)가 추가되었습니다. 도시 이름(한글 또는 영어)으로 검색이 가능합니다.

- **버그 수정**
  - 일부 엔드포인트(/api/home/*)에 인증 없이 접근할 수 있도록 보안 설정이 변경되었습니다.

- **기타**
  - OpenAI 모델이 "gpt-4o"에서 "gpt-4o-mini"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->