### PR TITLE
[FEAT] 여행 계획 디테일 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
@@ -3,18 +3,15 @@ package com.ssafy.tlog.trip.plan.controller;
 import com.ssafy.tlog.common.response.ApiResponse;
 import com.ssafy.tlog.common.response.ResponseWrapper;
 import com.ssafy.tlog.config.security.CustomUserDetails;
+import com.ssafy.tlog.trip.plan.dto.TripPlanDetailResponseDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanRequestDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanResponseDto;
 import com.ssafy.tlog.trip.plan.service.TripPlanService;
-import com.ssafy.tlog.trip.record.dto.TripRecordResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,4 +28,14 @@ public class TripPlanController {
         TripPlanResponseDto responseDto = tripPlanService.createTripPlan(requestDto, userDetails.getUser());
         return ApiResponse.success(HttpStatus.OK, "여행 계획이 성공적으로 저장되었습니다.",responseDto);
     }
+
+    @GetMapping("/{tripId}/plan")
+    public ResponseEntity<ResponseWrapper<TripPlanDetailResponseDto>> getTripPlanDetail(
+            @PathVariable int tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripPlanDetailResponseDto responseDto = tripPlanService.getTripPlanDetail(tripId, userDetails.getUser());
+        return ApiResponse.success(HttpStatus.OK, "여행 계획 조회가 성공적으로 완료되었습니다.", responseDto);
+    }
+
 }

--- a/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanDetailResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/dto/TripPlanDetailResponseDto.java
@@ -1,0 +1,43 @@
+package com.ssafy.tlog.trip.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TripPlanDetailResponseDto {
+
+    // Trip 정보
+    private int tripId;
+    private int cityId;
+    private String title;
+    private LocalDateTime createAt;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    // 계획 장소들
+    private List<PlanDetailDto> plans;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PlanDetailDto {
+        private int planId;
+        private String placeId;
+        private String placeName;
+        private Double latitude;
+        private Double longitude;
+        private int day;
+        private int planOrder;
+        private int placeTypeId;
+        private String memo;
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
@@ -1,15 +1,20 @@
 package com.ssafy.tlog.trip.plan.service;
 
-import com.ssafy.tlog.entity.*;
+import com.ssafy.tlog.entity.Trip;
+import com.ssafy.tlog.entity.TripParticipant;
+import com.ssafy.tlog.entity.TripPlan;
+import com.ssafy.tlog.entity.User;
 import com.ssafy.tlog.repository.TripParticipantRepository;
 import com.ssafy.tlog.repository.TripPlanRepository;
 import com.ssafy.tlog.repository.TripRepository;
+import com.ssafy.tlog.trip.plan.dto.TripPlanDetailResponseDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanRequestDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -64,4 +69,44 @@ public class TripPlanService {
                 .tripId(trip.getTripId())
                 .build();
     }
+
+    public TripPlanDetailResponseDto getTripPlanDetail(int tripId, User user) {
+        // 1. 해당 여행에 참여하는지 확인
+        if (!tripParticipantRepository.existsByTripIdAndUserId(tripId, user.getUserId())) {
+            throw new IllegalArgumentException("해당 여행에 참여하지 않은 사용자입니다.");
+        }
+
+        // 2. Trip 정보 조회
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행입니다."));
+
+        // 3. TripPlan 정보 조회 (day, planOrder 순으로 정렬)
+        List<TripPlan> tripPlans = tripPlanRepository.findAllByTripIdOrderByDayAscPlanOrderAsc(tripId);
+
+        // 4. DTO 변환
+        List<TripPlanDetailResponseDto.PlanDetailDto> planDetails = tripPlans.stream()
+                .map(plan -> TripPlanDetailResponseDto.PlanDetailDto.builder()
+                        .planId(plan.getPlanId())
+                        .placeId(plan.getPlaceId())
+                        .placeName(plan.getPlaceName())
+                        .latitude(plan.getLatitude())
+                        .longitude(plan.getLongitude())
+                        .day(plan.getDay())
+                        .planOrder(plan.getPlanOrder())
+                        .placeTypeId(plan.getPlaceTypeId())
+                        .memo(plan.getMemo())
+                        .build())
+                .toList();
+
+        return TripPlanDetailResponseDto.builder()
+                .tripId(trip.getTripId())
+                .cityId(trip.getCityId())
+                .title(trip.getTitle())
+                .createAt(trip.getCreateAt())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .plans(planDetails)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
여행 계획 디테일 조회 API 구현

## 📌 이슈 넘버
- #23 

## 📝 작업 내용

- 여행 계획 디테일 조회 api 구현
- api 명세서 업데이트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 여행 계획 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다. 이제 여행의 세부 일정, 장소 정보, 메모 등 상세 내용을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->