### PR TITLE
[Feat] 여행 계획 수정 및 기록 동기화 기

### DIFF
--- a/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
@@ -5,6 +5,8 @@ import com.ssafy.tlog.entity.TripParticipantId;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TripParticipantRepository extends JpaRepository<TripParticipant, TripParticipantId> {
 
@@ -12,4 +14,8 @@ public interface TripParticipantRepository extends JpaRepository<TripParticipant
     List<TripParticipant> findAllByTripIdIn(List<Integer> tripIds);
     List<TripParticipant> findAllByTripId(int tripId);
     boolean existsByTripIdAndUserId(int tripId, int userId);
+
+    @Modifying
+    @Query("DELETE FROM TripParticipant tp WHERE tp.tripId = :tripId AND tp.userId != :userId")
+    void deleteAllByTripIdExceptUser(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TripPlanRepository extends JpaRepository<TripPlan, Integer> {
     List<TripPlan> findAllByTripIdOrderByDayAscPlanOrderAsc(int tripId);
     boolean existsByTripId(int tripId);
+    void deleteAllByTripId(int tripId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
@@ -4,9 +4,17 @@ import com.ssafy.tlog.entity.TripRecord;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TripRecordRepository extends JpaRepository<TripRecord, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
+
     List<TripRecord> findAllByTripIdAndUserIdOrderByDay(int tripId, int userId);
+
     Optional<TripRecord> findByTripIdAndUserIdAndDay(int tripId, int userId, int day);
+
+    @Modifying
+    @Query("DELETE FROM TripRecord tr WHERE tr.tripId = :tripId AND tr.userId = :userId AND tr.day > :maxDay")
+    void deleteExcessRecords(int tripId, int userId, int maxDay);
 }

--- a/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
@@ -29,6 +29,16 @@ public class TripPlanController {
         return ApiResponse.success(HttpStatus.OK, "여행 계획이 성공적으로 저장되었습니다.",responseDto);
     }
 
+    @PutMapping("/{tripId}/plan")
+    public ResponseEntity<ResponseWrapper<TripPlanResponseDto>> updateTripPlan(
+            @PathVariable int tripId,
+            @RequestBody TripPlanRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripPlanResponseDto responseDto = tripPlanService.updateTripPlan(tripId, requestDto, userDetails.getUser());
+        return ApiResponse.success(HttpStatus.OK, "여행 계획이 성공적으로 수정되었습니다.", responseDto);
+    }
+
     @GetMapping("/{tripId}/plan")
     public ResponseEntity<ResponseWrapper<TripPlanDetailResponseDto>> getTripPlanDetail(
             @PathVariable int tripId,

--- a/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/service/TripPlanService.java
@@ -11,11 +11,11 @@ import com.ssafy.tlog.repository.UserRepository;
 import com.ssafy.tlog.trip.plan.dto.TripPlanDetailResponseDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanRequestDto;
 import com.ssafy.tlog.trip.plan.dto.TripPlanResponseDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,7 @@ public class TripPlanService {
     private final TripParticipantRepository tripParticipantRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public TripPlanResponseDto createTripPlan(TripPlanRequestDto requestDto, User creator) {
         Trip trip = Trip.builder()
                 .cityId(requestDto.getCityId())
@@ -43,7 +44,7 @@ public class TripPlanService {
                 .build();
         tripParticipantRepository.save(creatorParticipant);
 
-// 2. 친구 추가
+        // 2. 친구 추가
         requestDto.getFriendUserIds().forEach(friendId -> {
             TripParticipant friendParticipant = TripParticipant.builder()
                     .tripId(trip.getTripId())
@@ -51,7 +52,6 @@ public class TripPlanService {
                     .build();
             tripParticipantRepository.save(friendParticipant);
         });
-
 
         for (TripPlanRequestDto.PlaceDto placeDto : requestDto.getPlaces()) {
             TripPlan plan = TripPlan.builder()
@@ -126,6 +126,70 @@ public class TripPlanService {
                 .endDate(trip.getEndDate())
                 .plans(planDetails)
                 .participants(participantDtos) // 참여자 정보 추가
+                .build();
+    }
+
+    @Transactional
+    public TripPlanResponseDto updateTripPlan(int tripId, TripPlanRequestDto requestDto, User user) {
+        // 1. 여행 존재 여부 및 권한 확인
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행입니다."));
+
+        if (!tripParticipantRepository.existsByTripIdAndUserId(tripId, user.getUserId())) {
+            throw new IllegalArgumentException("해당 여행 계획을 수정할 권한이 없습니다.");
+        }
+
+        // 2. 여행 기본 정보 업데이트 (제목, 날짜 등)
+        if (requestDto.getTitle() != null) {
+            trip.setTitle(requestDto.getTitle());
+        }
+        if (requestDto.getStartDate() != null) {
+            trip.setStartDate(requestDto.getStartDate());
+        }
+        if (requestDto.getEndDate() != null) {
+            trip.setEndDate(requestDto.getEndDate());
+        }
+        if (requestDto.getCityId() != 0) {
+            trip.setCityId(requestDto.getCityId());
+        }
+        tripRepository.save(trip);
+
+        // 3. 기존 TripPlan들 삭제
+        tripPlanRepository.deleteAllByTripId(tripId);
+
+        // 4. 기존 참여자들 삭제 (본인 제외)
+        tripParticipantRepository.deleteAllByTripIdExceptUser(tripId, user.getUserId());
+
+        // 5. 새로운 친구들 추가
+        if (requestDto.getFriendUserIds() != null && !requestDto.getFriendUserIds().isEmpty()) {
+            requestDto.getFriendUserIds().forEach(friendId -> {
+                TripParticipant friendParticipant = TripParticipant.builder()
+                        .tripId(tripId)
+                        .userId(friendId)
+                        .build();
+                tripParticipantRepository.save(friendParticipant);
+            });
+        }
+
+        // 6. 새로운 장소들 추가
+        if (requestDto.getPlaces() != null && !requestDto.getPlaces().isEmpty()) {
+            for (TripPlanRequestDto.PlaceDto placeDto : requestDto.getPlaces()) {
+                TripPlan plan = TripPlan.builder()
+                        .tripId(tripId)
+                        .placeName(placeDto.getName())
+                        .placeId(placeDto.getPlaceId())
+                        .latitude(placeDto.getLatitude())
+                        .longitude(placeDto.getLongitude())
+                        .day(placeDto.getDay())
+                        .planOrder(placeDto.getOrder())
+                        .placeTypeId(placeDto.getPlaceType())
+                        .build();
+                tripPlanRepository.save(plan);
+            }
+        }
+
+        return TripPlanResponseDto.builder()
+                .tripId(tripId)
                 .build();
     }
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 여행 계획 수정 API 및 여행 기록 조회 시 데이터 동기화 기능

## 📌 이슈 넘버
- #30 

## 📝 작업 내용
- 여행 계획 수정 API: 기존 여행 계획을 수정할 수 있는 PUT API 추가
- 여행 기록 동기화: 여행 계획 변경 시 기록 데이터 자동 동기화
- 초과 기록 삭제: 여행 일수보다 많은 기록 자동 삭제
