### PR TITLE
[Feat] 카드에 이미지 추가 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/tlog/config/security/SecurityConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/security/SecurityConfig.java
@@ -47,23 +47,31 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, UserRepository userRepository) throws Exception {
         http.cors(Customizer.withDefaults())
-            .csrf(csrf -> csrf.disable())
-            .formLogin(form -> form.disable())
-            .httpBasic(basic -> basic.disable())
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-name","/api/auth/refresh","/api/home/*", "/api/users/check").permitAll()  // 로그인, 회원가입, 닉네임 확인은 인증 없이 접근 가능
-                    .anyRequest().authenticated()
-            )
-            .addFilterBefore(new JWTFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
-            .sessionManagement(session ->
-                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .exceptionHandling(ex -> ex
-                    .authenticationEntryPoint((request, response, authException) -> {
-                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                        response.setContentType("application/json; charset=UTF-8");
-                        response.getWriter().write("{\"statusCode\":401,\"errorCode\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다.\"}");
-                    })
-            );
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login",
+                                "/api/auth/signup",
+                                "/api/auth/check-name",
+                                "/api/auth/refresh",
+                                "/api/home/*",
+                                "/api/users/check",
+                                "/images/**"
+                        ).permitAll()  // 로그인, 회원가입, 닉네임 확인은 인증 없이 접근 가능
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JWTFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json; charset=UTF-8");
+                            response.getWriter()
+                                    .write("{\"statusCode\":401,\"errorCode\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다.\"}");
+                        })
+                );
 
         return http.build();
     }

--- a/src/main/java/com/ssafy/tlog/config/web/StaticResourceConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/web/StaticResourceConfig.java
@@ -1,0 +1,20 @@
+package com.ssafy.tlog.config.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.path:/uploads/images/}")
+    private String uploadPath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 이미지 파일을 정적 리소스로 서빙
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadPath);
+    }
+}

--- a/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
@@ -1,11 +1,16 @@
 package com.ssafy.tlog.config.web;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.path:/uploads/images/}")
+    private String uploadPath;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -15,5 +20,24 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization") // Authorization 헤더 노출 설정 추가
                 .allowCredentials(true); // 쿠키를 주고받을 경우
+
+        // 이미지 경로에 대한 CORS 설정 추가
+        registry.addMapping("/images/**")
+                .allowedOrigins("http://localhost:5173", "http://localhost:3000")
+                .allowedMethods("GET")
+                .allowedHeaders("*")
+                .allowCredentials(false); // 이미지는 credentials 불필요
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 이미지 파일을 정적 리소스로 서빙
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadPath)
+                .setCachePeriod(3600) // 1시간 캐시
+                .resourceChain(true);
+
+        // 디버깅을 위한 로그
+        System.out.println("이미지 리소스 핸들러 설정 완료: /images/** -> " + uploadPath);
     }
 }

--- a/src/main/java/com/ssafy/tlog/entity/TripImage.java
+++ b/src/main/java/com/ssafy/tlog/entity/TripImage.java
@@ -1,0 +1,24 @@
+package com.ssafy.tlog.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class TripImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int imageId;
+
+    private int tripId;
+    private int userId;
+    private int day;
+    private String imageUrl;      // 이미지 파일 URL
+    private String originalName;  // 원본 파일명
+    private long fileSize;        // 파일 크기
+}

--- a/src/main/java/com/ssafy/tlog/repository/TripImageRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripImageRepository.java
@@ -1,0 +1,12 @@
+package com.ssafy.tlog.repository;
+
+import com.ssafy.tlog.entity.TripImage;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripImageRepository extends JpaRepository<TripImage, Integer> {
+    List<TripImage> findAllByTripIdAndUserIdOrderByDay(int tripId, int userId);
+    Optional<TripImage> findByTripIdAndUserIdAndDay(int tripId, int userId, int day);
+    void deleteByTripIdAndUserIdAndDay(int tripId, int userId, int day);
+}

--- a/src/main/java/com/ssafy/tlog/trip/record/controller/ImageUploadController.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/controller/ImageUploadController.java
@@ -1,0 +1,64 @@
+package com.ssafy.tlog.trip.record.controller;
+
+import com.ssafy.tlog.common.response.ApiResponse;
+import com.ssafy.tlog.common.response.ResponseWrapper;
+import com.ssafy.tlog.config.security.CustomUserDetails;
+import com.ssafy.tlog.trip.record.service.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trips")
+public class ImageUploadController {
+
+    private final FileUploadService fileUploadService;
+
+    @PostMapping("/image/upload")
+    public ResponseEntity<ResponseWrapper<ImageUploadResponseDto>> uploadImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file) {
+
+        try {
+            String imageUrl = fileUploadService.uploadImage(file);
+
+            ImageUploadResponseDto responseDto = ImageUploadResponseDto.builder()
+                    .imageUrl(imageUrl)
+                    .originalName(file.getOriginalFilename())
+                    .fileSize(file.getSize())
+                    .build();
+
+            return ApiResponse.success(HttpStatus.OK, "이미지 업로드가 완료되었습니다.", responseDto);
+
+        } catch (IllegalArgumentException e) {
+            log.warn("이미지 업로드 검증 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(new ResponseWrapper<>(400, e.getMessage(), null));
+        } catch (Exception e) {
+            log.error("이미지 업로드 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseWrapper<>(500, "이미지 업로드 중 오류가 발생했습니다.", null));
+        }
+    }
+
+    // 응답 DTO
+    @lombok.Getter
+    @lombok.Setter
+    @lombok.Builder
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    public static class ImageUploadResponseDto {
+        private String imageUrl;
+        private String originalName;
+        private long fileSize;
+    }
+}

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordDetailResponseDto.java
@@ -45,5 +45,7 @@ public class TripRecordDetailResponseDto {
         private int day;
         private LocalDateTime date;
         private String memo;
+        private String imageUrl;      // 추가된 필드
+        private String originalName;  // 추가된 필드
     }
 }

--- a/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordSaveRequestDto.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/dto/TripRecordSaveRequestDto.java
@@ -16,5 +16,7 @@ public class TripRecordSaveRequestDto {
         private int day;
         private LocalDate date;
         private String memo;
+        private String imageUrl;      // 추가된 필드
+        private String originalName;  // 추가된 필드
     }
 }

--- a/src/main/java/com/ssafy/tlog/trip/record/service/FileUploadService.java
+++ b/src/main/java/com/ssafy/tlog/trip/record/service/FileUploadService.java
@@ -1,0 +1,110 @@
+package com.ssafy.tlog.trip.record.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+public class FileUploadService {
+
+    @Value("${file.upload.path:/uploads/images/}")
+    private String uploadPath;
+
+    @Value("${file.upload.url:http://localhost:8080/images/}")
+    private String baseUrl;
+
+    public String uploadImage(MultipartFile file) throws IOException {
+        log.info("이미지 업로드 시작: {}, 크기: {}", file.getOriginalFilename(), file.getSize());
+
+        // 파일 검증
+        validateImageFile(file);
+
+        // 업로드 디렉토리 생성
+        Path uploadDir = Paths.get(uploadPath);
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+            log.info("업로드 디렉토리 생성: {}", uploadDir);
+        }
+
+        // 고유한 파일명 생성
+        String originalFilename = file.getOriginalFilename();
+        String extension = getFileExtension(originalFilename);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String uniqueFilename = timestamp + "_" + UUID.randomUUID().toString() + "." + extension;
+
+        // 파일 저장
+        Path filePath = uploadDir.resolve(uniqueFilename);
+        Files.write(filePath, file.getBytes());
+
+        log.info("파일 저장 완료: {}", filePath);
+
+        // 접근 가능한 URL 반환
+        String imageUrl = baseUrl + uniqueFilename;
+        log.info("생성된 이미지 URL: {}", imageUrl);
+
+        return imageUrl;
+    }
+
+    public void deleteImage(String imageUrl) {
+        try {
+            if (imageUrl != null && imageUrl.startsWith(baseUrl)) {
+                String filename = imageUrl.substring(baseUrl.length());
+                Path filePath = Paths.get(uploadPath, filename);
+                if (Files.exists(filePath)) {
+                    Files.delete(filePath);
+                    log.info("이미지 파일 삭제 완료: {}", filename);
+                } else {
+                    log.warn("삭제할 파일이 존재하지 않음: {}", filePath);
+                }
+            }
+        } catch (IOException e) {
+            log.error("이미지 파일 삭제 실패: {}", imageUrl, e);
+        }
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        // 파일 크기 검증 (10MB 제한)
+        long maxSize = 10 * 1024 * 1024; // 10MB
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+
+        // 파일 타입 검증
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다.");
+        }
+
+        // 허용되는 확장자 검증
+        String extension = getFileExtension(file.getOriginalFilename());
+        if (!isAllowedExtension(extension)) {
+            throw new IllegalArgumentException("지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif만 가능)");
+        }
+
+        log.info("파일 검증 완료: {} ({})", file.getOriginalFilename(), contentType);
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private boolean isAllowedExtension(String extension) {
+        return extension.matches("jpg|jpeg|png|gif");
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -23,3 +23,5 @@ spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.timeout=${REDIS_TIMEOUT}ms
 spring.data.redis.database=${REDIS_DATABASE}
+
+file.upload.url=${FILE_UPLOAD_URL}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=Tlog
 
 # prod
-#spring.profiles.active=prod
+spring.profiles.active=prod
 
 # local
-spring.profiles.active=local
+#spring.profiles.active=local
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=none
@@ -14,9 +14,9 @@ spring.jpa.open-in-view=false
 
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
-# ?? ??? ?? ??
+# File upload configuration
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
-# ?? ??? ?? ??
-file.upload.path=/uploads/images/
+# File upload path configuration
+file.upload.path=${FILE_UPLOAD_PATH:/uploads/images/}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=Tlog
 
 # prod
-spring.profiles.active=prod
+#spring.profiles.active=prod
 
 # local
-#spring.profiles.active=local
+spring.profiles.active=local
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=none
@@ -13,3 +13,10 @@ spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.open-in-view=false
 
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# ?? ??? ?? ??
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+# ?? ??? ?? ??
+file.upload.path=/uploads/images/


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
>카드에 이미지 추가 기능 구현

## 📌 이슈 넘버
- #30

## 📝 작업 내용
- FileUploadService: 이미지 업로드, 검증, 삭제 로직 구현
- ImageUploadController: 이미지 업로드 API 엔드포인트 추가
- TripImage 엔티티: 이미지 정보 저장을 위한 엔티티 생성
- TripImageRepository: 이미지 관련 데이터베이스 작업을 위한 레포지토리 추가
- SecurityConfig, WebConfig, StaticResourceConfig: 이미지 관련 보안 및 리소스 설정 업데이트
- RecordService: 여행 기록 저장 시 이미지 정보 처리 로직 추가
- TripRecordDetailResponseDto, TripRecordSaveRequestDto: DTO에 이미지 관련 필드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행 기록에 이미지 업로드 및 관리 기능이 추가되었습니다. 이미지를 업로드하면 URL, 원본 파일명, 파일 크기 정보가 제공됩니다.
  - 업로드된 이미지는 `/images/**` 경로를 통해 접근할 수 있습니다.

- **문서화**
  - 환경설정 파일에 이미지 업로드 경로 및 용량 제한 관련 설정이 추가되었습니다.

- **기타**
  - 여행 기록 상세 및 저장 시 이미지 정보(이미지 URL, 원본 파일명)가 함께 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->