### PR TITLE
[Feat] 계획 삭제 버튼 추가 

### DIFF
--- a/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
+++ b/src/main/java/com/ssafy/tlog/config/web/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**") // 또는 모든 요청이라면 "/**"
-                .allowedOrigins("http://localhost:5173") // 개발 서버 주소
+                .allowedOrigins("http://localhost:5173", "http://localhost:5174") // 개발 서버 주소
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization") // Authorization 헤더 노출 설정 추가

--- a/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
@@ -3,12 +3,18 @@ package com.ssafy.tlog.repository;
 import com.ssafy.tlog.entity.AiStory;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface AiStoryRepository extends JpaRepository<AiStory, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
     Optional<AiStory> findByTripIdAndUserId(int tripId, int userId);
 
+    @Modifying
+    @Transactional
     void deleteByTripId(int tripId);
 
+    @Modifying
+    @Transactional
     void deleteByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/AiStoryRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AiStoryRepository extends JpaRepository<AiStory, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
     Optional<AiStory> findByTripIdAndUserId(int tripId, int userId);
+
+    void deleteByTripId(int tripId);
+
+    void deleteByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripParticipantRepository.java
@@ -18,4 +18,8 @@ public interface TripParticipantRepository extends JpaRepository<TripParticipant
     @Modifying
     @Query("DELETE FROM TripParticipant tp WHERE tp.tripId = :tripId AND tp.userId != :userId")
     void deleteAllByTripIdExceptUser(int tripId, int userId);
+
+    void deleteByTripIdAndUserId(int tripId, int userId);
+
+    void deleteByTripId(int tripId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripPlanRepository.java
@@ -8,4 +8,6 @@ public interface TripPlanRepository extends JpaRepository<TripPlan, Integer> {
     List<TripPlan> findAllByTripIdOrderByDayAscPlanOrderAsc(int tripId);
     boolean existsByTripId(int tripId);
     void deleteAllByTripId(int tripId);
+
+    void deleteByTripId(int tripId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
@@ -17,4 +17,8 @@ public interface TripRecordRepository extends JpaRepository<TripRecord, Integer>
     @Modifying
     @Query("DELETE FROM TripRecord tr WHERE tr.tripId = :tripId AND tr.userId = :userId AND tr.day > :maxDay")
     void deleteExcessRecords(int tripId, int userId, int maxDay);
+
+    void deleteByTripId(int tripId);
+
+    void deleteByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
+++ b/src/main/java/com/ssafy/tlog/repository/TripRecordRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface TripRecordRepository extends JpaRepository<TripRecord, Integer> {
     boolean existsByTripIdAndUserId(Integer tripId, int userId);
@@ -18,7 +19,11 @@ public interface TripRecordRepository extends JpaRepository<TripRecord, Integer>
     @Query("DELETE FROM TripRecord tr WHERE tr.tripId = :tripId AND tr.userId = :userId AND tr.day > :maxDay")
     void deleteExcessRecords(int tripId, int userId, int maxDay);
 
+    @Modifying
+    @Transactional
     void deleteByTripId(int tripId);
 
+    @Modifying
+    @Transactional
     void deleteByTripIdAndUserId(int tripId, int userId);
 }

--- a/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
+++ b/src/main/java/com/ssafy/tlog/trip/plan/controller/TripPlanController.java
@@ -48,4 +48,18 @@ public class TripPlanController {
         return ApiResponse.success(HttpStatus.OK, "여행 계획 조회가 성공적으로 완료되었습니다.", responseDto);
     }
 
+    @DeleteMapping("/{tripId}")
+    public ResponseEntity<ResponseWrapper<Void>> deleteTrip(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable int tripId) {
+
+        boolean isLastParticipant = tripPlanService.deleteUserFromTrip(userDetails.getUserId(), tripId);
+
+        String message = isLastParticipant ?
+                "여행이 성공적으로 삭제되었습니다." :
+                "여행에서 성공적으로 탈퇴했습니다.";
+
+        return ApiResponse.success(HttpStatus.OK, message);
+    }
+
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
> 여행 계획 페이지 - 여행 삭제/탈퇴 기능 추가

## 📌 이슈 넘버
- #30 

## 📝 작업 내용
- 여행 삭제/탈퇴 API 추가: 사용자가 여행에서 탈퇴하거나 여행을 완전히 삭제할 수 있는 기능
- 스마트 삭제 로직: 참여자 수에 따라 탈퇴 또는 전체 삭제를 자동으로 판단


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 사용자가 여행에서 나가기 및 여행 삭제 기능이 추가되었습니다. 사용자가 마지막 참가자인 경우 전체 여행이 삭제되고, 그렇지 않은 경우 해당 사용자가 여행에서 나가게 됩니다.
- **기타**
	- CORS 허용 도메인에 "http://localhost:5174"가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->